### PR TITLE
fix var names in config import

### DIFF
--- a/luci-app-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
+++ b/luci-app-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
@@ -402,15 +402,15 @@ return network.registerProtocol('amneziawg', {
 					s.getOption('public_key').getUIElement(s.section).setValue(keypair.pub);
 					s.getOption('listen_port').getUIElement(s.section).setValue(config.interface_listenport || '');
 					s.getOption('addresses').getUIElement(s.section).setValue(config.interface_address);
-                    s.getOption('awg_jc').getUIElement(s.section).setValue(config.awg_jc);
-                    s.getOption('awg_jmin').getUIElement(s.section).setValue(config.awg_jmin);
-                    s.getOption('awg_jmax').getUIElement(s.section).setValue(config.awg_jmax);
-                    s.getOption('awg_s1').getUIElement(s.section).setValue(config.awg_s1);
-                    s.getOption('awg_s2').getUIElement(s.section).setValue(config.awg_s2);
-                    s.getOption('awg_h1').getUIElement(s.section).setValue(config.awg_h1);
-                    s.getOption('awg_h2').getUIElement(s.section).setValue(config.awg_h2);
-                    s.getOption('awg_h3').getUIElement(s.section).setValue(config.awg_h3);
-                    s.getOption('awg_h4').getUIElement(s.section).setValue(config.awg_h4);
+                    			s.getOption('awg_jc').getUIElement(s.section).setValue(config.interface_jc);
+					s.getOption('awg_jmin').getUIElement(s.section).setValue(config.interface_jmin);
+                    			s.getOption('awg_jmax').getUIElement(s.section).setValue(config.interface_jmax);
+                    			s.getOption('awg_s1').getUIElement(s.section).setValue(config.interface_s1);
+                    			s.getOption('awg_s2').getUIElement(s.section).setValue(config.interface_s2);
+                    			s.getOption('awg_h1').getUIElement(s.section).setValue(config.interface_h1);
+                    			s.getOption('awg_h2').getUIElement(s.section).setValue(config.interface_h2);
+                    			s.getOption('awg_h3').getUIElement(s.section).setValue(config.interface_h3);
+                    			s.getOption('awg_h4').getUIElement(s.section).setValue(config.interface_h4);
 
 					if (config.interface_dns)
 						s.getOption('dns').getUIElement(s.section).setValue(config.interface_dns);


### PR DESCRIPTION
Исправлены названия переменных для корректного импорта текстовой конфигурации