### PR TITLE
fix: Use new SVG icon

### DIFF
--- a/luci-app-amneziawg/htdocs/luci-static/resources/view/amneziawg/status.js
+++ b/luci-app-amneziawg/htdocs/luci-static/resources/view/amneziawg/status.js
@@ -128,7 +128,7 @@ return view.extend({
 					'click': ui.createHandlerFn(this, handleInterfaceDetails, ifaces[instanceName])
 				}, [
 					E('span', { 'class': 'ifacebadge' }, [
-						E('img', { 'src': L.resource('icons', 'tunnel.png') }),
+						E('img', { 'src': L.resource('icons', 'tunnel.svg') }),
 						'\xa0',
 						instanceName
 					]),


### PR DESCRIPTION
В OpenWRT 24.10.1 все старые иконки заменили на новые векторные в формате SVG из-за чего на странице статуса не отображается иконка.

<img width="600" height="191" alt="изображение" src="https://github.com/user-attachments/assets/1d8afac3-f0b7-45e3-9aad-d24c1c307706" />
