### PR TITLE
luci: handle oversized peer config QR generation gracefully

### DIFF
--- a/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
+++ b/luci-proto-amneziawg/htdocs/luci-static/resources/protocol/amneziawg.js
@@ -72,9 +72,25 @@ function buildSVGQRCode(data, code) {
 		whiteColor: 'white',
 		blackColor: 'black'
 	};
-	const svg = uqr.renderSVG(data, options);
-	code.style.opacity = '';
-	dom.content(code, Object.assign(E(svg), { style: 'width:100%;height:auto' }));
+
+	try {
+		const svg = uqr.renderSVG(data, options);
+		code.style.opacity = '';
+		dom.content(code, Object.assign(E(svg), {
+			style: 'width:100%;height:auto'
+		}));
+	}
+	catch (e) {
+		console.warn('QR generation failed:', e);
+
+		code.style.opacity = '';
+		dom.content(code, E('div', {
+			'class': 'alert-message warning',
+			'style': 'margin:0;text-align:center'
+		}, [
+			_('QR code generation failed. The configuration may be too large.')
+		]));
+	}
 }
 
 var cbiKeyPairGenerate = form.DummyValue.extend({


### PR DESCRIPTION
Currently generated config isn't shown at all ("Generate configuration..." button seemingly doing nothing), when QR code generation fails.

Catch QR rendering failures when exporting peer configurations and show a user-facing message instead of failing silently (for example when large I1-I5 values present).