### PR TITLE
Add CLI arguments for disabling questions about interface configuration and translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@
 ```
 sh <(wget -O - https://raw.githubusercontent.com/Slava-Shchipunov/awg-openwrt/refs/heads/master/amneziawg-install.sh)
 ```
-
-3) Кроме того для автоматической настройки также можно использовать [скрипт](https://github.com/itdoginfo/domain-routing-openwrt) от пользователя [@itdoginfo](https://github.com/itdoginfo). Этот скрипт позволяет автоматически скачать нужные пакеты из собранных здесь и настроить [точечный обход блокировок по доменам](https://habr.com/ru/articles/767464/). Подойдёт, если у вас слабый роутер с недостаточным объёмом ROM для установки podkop-a и зависимостей
+3) Также предусмотрен неинтерактивный режим простой установки пакетов (без вопросов о настройке интерфейса с протоколом AmneziaWG и установке пакета `luci-i18n-amneziawg-ru`):
+```
+sh <(wget -O - https://raw.githubusercontent.com/Slava-Shchipunov/awg-openwrt/refs/heads/master/amneziawg-install.sh) -en
+```  
+4) Кроме того для автоматической настройки также можно использовать [скрипт](https://github.com/itdoginfo/domain-routing-openwrt) от пользователя [@itdoginfo](https://github.com/itdoginfo). Этот скрипт позволяет автоматически скачать нужные пакеты из собранных здесь и настроить [точечный обход блокировок по доменам](https://habr.com/ru/articles/767464/). Подойдёт, если у вас слабый роутер с недостаточным объёмом ROM для установки podkop-a и зависимостей
 
 ## Сборка пакетов для всех устройств, поддерживающих OpenWRT
 В репозиторий добавлен скрипт, который парсит данные о поддерживаемых платформах со страницы OpenWRT и автоматически запускает сборку пакетов AmneziaWG для всех устройств.

--- a/README.md
+++ b/README.md
@@ -84,8 +84,11 @@ To run the script, connect to the router via SSH, enter the command and follow t
 ```
 sh <(wget -O - https://raw.githubusercontent.com/Slava-Shchipunov/awg-openwrt/refs/heads/master/amneziawg-install.sh)
 ```
-
-3) In addition, for automatic configuration you can also use the [script](https://github.com/itdoginfo/domain-routing-openwrt) from user [@itdoginfo](https://github.com/itdoginfo). This script allows you to automatically download the necessary packages from those collected here and configure [point-by-point bypass of blocking by domains](https://habr.com/ru/articles/767464/) (instructions in Russian). Suitable if you have a weak router with insufficient ROM to install podkop and its dependencies
+3) There is also a non-interactive mode for simple package installation (without questions about configuring an interface with the AmneziaWG protocol and installing the `luci-i18n-amneziawg-ru` package):
+```
+sh <(wget -O - https://raw.githubusercontent.com/Slava-Shchipunov/awg-openwrt/refs/heads/master/amneziawg-install.sh) -en
+```
+4) In addition, for automatic configuration you can also use the [script](https://github.com/itdoginfo/domain-routing-openwrt) from user [@itdoginfo](https://github.com/itdoginfo). This script allows you to automatically download the necessary packages from those collected here and configure [point-by-point bypass of blocking by domains](https://habr.com/ru/articles/767464/) (instructions in Russian). Suitable if you have a weak router with insufficient ROM to install podkop and its dependencies
 
 # Building packages for all devices that support OpenWRT
 A script has been added to the repository that parses data on supported platforms from the OpenWRT page and automatically starts building AmneziaWG packages for all devices.

--- a/amneziawg-install.sh
+++ b/amneziawg-install.sh
@@ -5,6 +5,16 @@
 PKG_MANAGER=""
 PKG_EXT=""
 
+usage() {
+    cat <<EOF
+Usage: ${0##*/} [-h] [-e] [-n]
+    -h    show this help
+    -e    do not install 'luci-i18n-amneziawg-ru' package
+    -n    do not configure the amneziawg interface
+EOF
+    exit 0
+}
+
 detect_package_manager() {
     if command -v apk >/dev/null 2>&1; then
         PKG_MANAGER="apk"
@@ -211,7 +221,7 @@ install_awg_packages() {
     fi
 
     # Устанавливаем русскую локализацию только для AWG 2.0
-    if [ "$AWG_VERSION" = "2.0" ]; then
+    if [ "$AWG_VERSION" = "2.0" ] && [ $ASK_FOR_TRANSLATION = 1 ]; then
         printf "\033[32;1mУстанавливаем пакет с русской локализацией? Install Russian language pack? (y/n) [n]: \033[0m\n"
         read INSTALL_RU_LANG
         INSTALL_RU_LANG=${INSTALL_RU_LANG:-n}
@@ -363,7 +373,24 @@ configure_amneziawg_interface() {
 detect_package_manager
 check_repo
 
+ASK_FOR_TRANSLATION=1
+ASK_FOR_INTERFACE_CONFIG=1
+
+while getopts ":ehn" opt; do
+    case "$opt" in
+        h) usage ;;
+        e) ASK_FOR_TRANSLATION=0 ;;
+        n) ASK_FOR_INTERFACE_CONFIG=0 ;;
+        \?) echo "Unknown option -$OPTARG" >&2; usage ;;
+    esac
+done
+shift "$((OPTIND-1))"
+
 install_awg_packages
+
+if [ "$ASK_FOR_INTERFACE_CONFIG" = 0 ]; then
+    exit 0
+fi
 
 printf "\033[32;1mDo you want to configure the amneziawg interface? (y/n): \033[0m\n"
 read IS_SHOULD_CONFIGURE_AWG_INTERFACE

--- a/amneziawg-install.sh
+++ b/amneziawg-install.sh
@@ -370,9 +370,6 @@ configure_amneziawg_interface() {
     service network restart
 }
 
-detect_package_manager
-check_repo
-
 ASK_FOR_TRANSLATION=1
 ASK_FOR_INTERFACE_CONFIG=1
 
@@ -385,6 +382,9 @@ while getopts ":ehn" opt; do
     esac
 done
 shift "$((OPTIND-1))"
+
+detect_package_manager
+check_repo
 
 install_awg_packages
 


### PR DESCRIPTION
При обновлении роутеров хочется, чтобы пакеты awg устанавливались автоматически, но интерактивный режим, используемый скриптом установки по умолчанию, блокирует такую возможность.

В этом ПР добавил 2 аргумента для скрипта установки:
- аргумент `-e` отключает вопрос об установке пакета локализации `luci-i18n-amneziawg-ru`;
- аргумент `-n` отключает вопрос о настройке awg интерфейса.

Таким образом, указывая оба аргумента, можно получить неинтерактивный режим установки минимального набора пакетов.

Также вынес в README.md информацию о запуске с аргументами.