### PR TITLE
amneziawg-tools: add dependency on kmod-amneziawg

### DIFF
--- a/amneziawg-tools/Makefile
+++ b/amneziawg-tools/Makefile
@@ -20,14 +20,16 @@ MAKE_PATH:=src
 MAKE_VARS += PLATFORM=linux
 
 define Package/amneziawg-tools
+  SECTION:=net
   CATEGORY:=Network
   SUBMENU:=VPN
   URL:=https://amnezia.org/
   MAINTAINER:=Amnezia Admin <admin@amnezia.org>
   TITLE:=AmneziaWG userspace control program (awg)
   DEPENDS:= \
-	  +@BUSYBOX_CONFIG_IP \
-	  +@BUSYBOX_CONFIG_FEATURE_IP_LINK
+	  +!BUSYBOX_CONFIG_IP:ip \
+	  +!BUSYBOX_CONFIG_FEATURE_IP_LINK:ip \
+	  +kmod-amneziawg
 endef
 
 define Package/amneziawg-tools/description


### PR DESCRIPTION
Добрый вечер!

У меня есть деплой OpenWrt-образов через Image Builder. После добавления `luci-proto-amneziawg` в список пакетов образ собрался некорректно: я ожидал, что `luci-proto-amneziawg` подтянет `amneziawg-tools`, а `amneziawg-tools`, в свою очередь, подтянет `kmod-amneziawg`.

Но в `amneziawg-tools/Makefile` зависимости на `kmod-amneziawg` не оказалось. 

В качестве ориентира я использовал актуальный Makefile `wireguard-tools` из OpenWrt 25.12:
https://github.com/openwrt/openwrt/blob/openwrt-25.12/package/network/utils/wireguard-tools/Makefile

Проверил локально через `act` для OpenWrt `25.12.3` и `x86/64`. Все пакеты собрались успешно:

- `kmod-amneziawg`
- `amneziawg-tools`
- `luci-proto-amneziawg`
- `luci-i18n-amneziawg-ru`

Также проверил metadata через `apk adbdump`:

- `amneziawg-tools` теперь зависит от `kmod-amneziawg`
- `luci-proto-amneziawg` зависит от `amneziawg-tools`