### PR TITLE
Prevent excessive firewall forwarding config with amneziawg-install.sh

### DIFF
--- a/amneziawg-install.sh
+++ b/amneziawg-install.sh
@@ -356,7 +356,7 @@ configure_amneziawg_interface() {
         uci commit firewall
     fi
 
-    if ! uci show firewall | grep -q "@forwarding.*name='${ZONE_NAME}'"; then
+    if ! uci show firewall | grep -q "@forwarding.*name='${ZONE_NAME}-lan'"; then
         printf "\033[32;1mConfigured forwarding\033[0m\n"
         uci add firewall forwarding
         uci set firewall.@forwarding[-1]=forwarding


### PR DESCRIPTION
Current grep for existing firewall forwarding in amneziawg-install.sh as
"@forwarding.*name='awg1'"
fail to match 'uci show firewall' output string (note '-lan' suffix)
firewall.@forwarding[1].name='awg1-lan'

As this match is failed new identical firewall forwarding awg1-lan is created with each amneziawg-install.sh run.